### PR TITLE
Use the OnSendingHeaders Mechanism

### DIFF
--- a/src/KestrelPureOwin/KestrelPureOwin.csproj
+++ b/src/KestrelPureOwin/KestrelPureOwin.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="1.1.0" />
   </ItemGroup>

--- a/src/KestrelPureOwin/OwinApplication.cs
+++ b/src/KestrelPureOwin/OwinApplication.cs
@@ -68,7 +68,19 @@ namespace KestrelPureOwin
             environment.Set(Server.User, authentication?.User);
             environment.Set(Server.Features, features);
 
+            response.OnStarting(SetStatus, (response, environment));
+
             return environment;
+        }
+
+        private static Task SetStatus(object state)
+        {
+            var (response, environment) = ((IHttpResponseFeature, Dictionary<string, object>)) state;
+
+            response.StatusCode = environment.Get<int>(Owin.Response.StatusCode);
+            response.ReasonPhrase = environment.Get<string>(Owin.Response.ReasonPhrase);
+
+            return Tasks.Completed;
         }
 
         public async Task ProcessRequestAsync(Dictionary<string, object> environment)
@@ -83,8 +95,6 @@ namespace KestrelPureOwin
 
             response.Body = environment.Get<Stream>(Owin.Response.Body);
             response.Headers = new ReverseOwinHeaderDictionary(owinHeaders);
-            response.StatusCode = environment.Get<int>(Owin.Response.StatusCode);
-            response.ReasonPhrase = environment.Get<string>(Owin.Response.ReasonPhrase);
         }
 
         public void DisposeContext(Dictionary<string, object> environment, Exception exception)


### PR DESCRIPTION
Kestrel supports Transfer-Encoding: chunked by default, which means that the body stream will have been written to by the time this gets around to setting the response headers.